### PR TITLE
AC-4: Add Performance Cycle UI with CRUD functionality

### DIFF
--- a/src/app/performancecycles/page.tsx
+++ b/src/app/performancecycles/page.tsx
@@ -1,0 +1,355 @@
+'use client';
+
+import React, { useState, useEffect } from 'react';
+import AdminLayout from '@/components/layout/AdminLayout';
+import { performanceCycleService, PerformanceCycle } from '@/services/performanceCycleService';
+import { PerformanceCycleForm } from '@/components/performancecycles/PerformanceCycleForm';
+import { useTenant } from '@/contexts/TenantContext';
+
+const PerformanceCyclesPage: React.FC = () => {
+  const { tenantId, companyId } = useTenant();
+  const [cycles, setCycles] = useState<PerformanceCycle[]>([]);
+  const [isLoading, setIsLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [editingItem, setEditingItem] = useState<PerformanceCycle | undefined>(undefined);
+  const [showForm, setShowForm] = useState(false);
+  const [searchTerm, setSearchTerm] = useState('');
+  const [filterActive, setFilterActive] = useState<'all' | 'active' | 'inactive'>('all');
+  const [sortField, setSortField] = useState<keyof PerformanceCycle | ''>('');
+  const [sortDirection, setSortDirection] = useState<'asc' | 'desc'>('asc');
+
+  // Load performance cycles
+  const loadCycles = async () => {
+    if (!tenantId) return;
+    
+    setIsLoading(true);
+    try {
+      const data = await performanceCycleService.getAll();
+      setCycles(data);
+      setError(null);
+    } catch (err) {
+      setError('Failed to load performance cycles. Please try again.');
+      console.error(err);
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  useEffect(() => {
+    loadCycles();
+  }, [tenantId]); // eslint-disable-line react-hooks/exhaustive-deps
+
+  const handleAddNew = () => {
+    setEditingItem(undefined);
+    setShowForm(true);
+  };
+
+  const handleEdit = (item: PerformanceCycle) => {
+    setEditingItem(item);
+    setShowForm(true);
+  };
+
+  const handleDelete = async (id: string) => {
+    if (window.confirm('Are you sure you want to delete this performance cycle?')) {
+      try {
+        await performanceCycleService.delete(id);
+        setCycles(cycles.filter(item => item.id !== id));
+      } catch (err) {
+        setError('Failed to delete performance cycle. Please try again.');
+        console.error(err);
+      }
+    }
+  };
+
+  const handleFormSubmit = async (data: Omit<PerformanceCycle, 'id'>) => {
+    try {
+      if (editingItem) {
+        await performanceCycleService.update(editingItem.id, data);
+      } else {
+        await performanceCycleService.create(data);
+      }
+      await loadCycles();
+      setShowForm(false);
+      setEditingItem(undefined);
+    } catch (err) {
+      console.error(err);
+      throw err;
+    }
+  };
+
+  const handleFormCancel = () => {
+    setShowForm(false);
+    setEditingItem(undefined);
+  };
+
+  // Filter cycles based on search term and active status
+  const filterCycles = (cycles: PerformanceCycle[]) => {
+    let filtered = cycles;
+
+    // Filter by active status
+    if (filterActive !== 'all') {
+      filtered = filtered.filter(cycle => 
+        filterActive === 'active' ? cycle.isActive : !cycle.isActive
+      );
+    }
+
+    // Filter by search term
+    if (searchTerm) {
+      filtered = filtered.filter(cycle =>
+        cycle.name.toLowerCase().includes(searchTerm.toLowerCase()) ||
+        (cycle.description && cycle.description.toLowerCase().includes(searchTerm.toLowerCase()))
+      );
+    }
+
+    return filtered;
+  };
+
+  // Sort cycles
+  const sortCycles = (cycles: PerformanceCycle[]) => {
+    if (!sortField) return cycles;
+
+    return [...cycles].sort((a, b) => {
+      const aValue = a[sortField as keyof PerformanceCycle];
+      const bValue = b[sortField as keyof PerformanceCycle];
+
+      if (aValue === bValue) return 0;
+
+      const comparison = aValue < bValue ? -1 : 1;
+      return sortDirection === 'asc' ? comparison : -comparison;
+    });
+  };
+
+  const handleSort = (field: keyof PerformanceCycle) => {
+    setSortDirection(
+      field === sortField && sortDirection === 'asc' ? 'desc' : 'asc'
+    );
+    setSortField(field);
+  };
+
+  const processedCycles = sortCycles(filterCycles(cycles));
+
+  const formatDate = (dateString?: string) => {
+    if (!dateString) return '-';
+    const date = new Date(dateString);
+    return date.toLocaleDateString('en-US', { 
+      year: 'numeric', 
+      month: 'short', 
+      day: 'numeric' 
+    });
+  };
+
+  return (
+    <AdminLayout>
+      <div className="content-header">
+        <div className="container-fluid">
+          <div className="row mb-2">
+            <div className="col-sm-6">
+              <h1 className="m-0">
+                <i className="fas fa-sync-alt mr-2"></i>
+                Performance Cycle Management
+              </h1>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <section className="content">
+        <div className="container-fluid">
+          <div className="card">
+            <div className="card-header">
+              <h3 className="card-title">Performance Cycles</h3>
+              <div className="card-tools">
+                <button
+                  type="button"
+                  className="btn btn-primary btn-sm"
+                  onClick={handleAddNew}
+                  disabled={showForm}
+                >
+                  <i className="fas fa-plus mr-1"></i> Add New Cycle
+                </button>
+              </div>
+            </div>
+            <div className="card-body">
+              {error && (
+                <div className="alert alert-danger">{error}</div>
+              )}
+
+              <div className="row mb-3">
+                <div className="col-md-4">
+                  <div className="input-group">
+                    <div className="input-group-prepend">
+                      <span className="input-group-text">
+                        <i className="fas fa-filter"></i>
+                      </span>
+                    </div>
+                    <select
+                      className="form-control"
+                      value={filterActive}
+                      onChange={(e) => setFilterActive(e.target.value as 'all' | 'active' | 'inactive')}
+                    >
+                      <option value="all">All Cycles</option>
+                      <option value="active">Active Only</option>
+                      <option value="inactive">Inactive Only</option>
+                    </select>
+                  </div>
+                </div>
+                <div className="col-md-8">
+                  <div className="input-group">
+                    <input
+                      type="text"
+                      className="form-control"
+                      placeholder="Search cycles..."
+                      value={searchTerm}
+                      onChange={(e) => setSearchTerm(e.target.value)}
+                    />
+                    <div className="input-group-append">
+                      <span className="input-group-text">
+                        <i className="fas fa-search"></i>
+                      </span>
+                    </div>
+                  </div>
+                </div>
+              </div>
+
+              <div className="table-responsive">
+                <table className="table table-bordered table-striped">
+                  <thead>
+                    <tr>
+                      <th
+                        onClick={() => handleSort('name')}
+                        style={{ cursor: 'pointer' }}
+                      >
+                        Cycle Name
+                        {sortField === 'name' && (
+                          <i
+                            className={`ml-1 fas fa-sort-${sortDirection === 'asc' ? 'up' : 'down'}`}
+                          ></i>
+                        )}
+                      </th>
+                      <th>Description</th>
+                      <th
+                        onClick={() => handleSort('startDate')}
+                        style={{ cursor: 'pointer' }}
+                      >
+                        Start Date
+                        {sortField === 'startDate' && (
+                          <i
+                            className={`ml-1 fas fa-sort-${sortDirection === 'asc' ? 'up' : 'down'}`}
+                          ></i>
+                        )}
+                      </th>
+                      <th
+                        onClick={() => handleSort('endDate')}
+                        style={{ cursor: 'pointer' }}
+                      >
+                        End Date
+                        {sortField === 'endDate' && (
+                          <i
+                            className={`ml-1 fas fa-sort-${sortDirection === 'asc' ? 'up' : 'down'}`}
+                          ></i>
+                        )}
+                      </th>
+                      <th>Type</th>
+                      <th
+                        onClick={() => handleSort('isActive')}
+                        style={{ cursor: 'pointer' }}
+                      >
+                        Status
+                        {sortField === 'isActive' && (
+                          <i
+                            className={`ml-1 fas fa-sort-${sortDirection === 'asc' ? 'up' : 'down'}`}
+                          ></i>
+                        )}
+                      </th>
+                      <th className="text-nowrap" style={{ minWidth: '140px' }}>Actions</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {isLoading ? (
+                      <tr>
+                        <td colSpan={7} className="text-center">
+                          <div className="spinner-border text-primary" role="status">
+                            <span className="sr-only">Loading...</span>
+                          </div>
+                        </td>
+                      </tr>
+                    ) : processedCycles.length === 0 ? (
+                      <tr>
+                        <td colSpan={7} className="text-center">
+                          No performance cycles found
+                        </td>
+                      </tr>
+                    ) : (
+                      processedCycles.map((cycle) => (
+                        <tr key={cycle.id}>
+                          <td>{cycle.name}</td>
+                          <td>{cycle.description || <em className="text-muted">No description</em>}</td>
+                          <td>{formatDate(cycle.startDate)}</td>
+                          <td>{formatDate(cycle.endDate)}</td>
+                          <td>
+                            {cycle.isTimeSensitive ? (
+                              <span className="badge badge-warning">
+                                <i className="fas fa-clock mr-1"></i>
+                                Time-sensitive
+                              </span>
+                            ) : (
+                              <span className="badge badge-info">
+                                <i className="fas fa-infinity mr-1"></i>
+                                Ongoing
+                              </span>
+                            )}
+                          </td>
+                          <td>
+                            {cycle.isActive ? (
+                              <span className="badge badge-success">
+                                <i className="fas fa-check-circle mr-1"></i>
+                                Active
+                              </span>
+                            ) : (
+                              <span className="badge badge-secondary">
+                                <i className="fas fa-times-circle mr-1"></i>
+                                Inactive
+                              </span>
+                            )}
+                          </td>
+                          <td className="text-nowrap">
+                            <button
+                              className="btn btn-info btn-sm mr-2"
+                              onClick={() => handleEdit(cycle)}
+                              disabled={showForm}
+                            >
+                              <i className="fas fa-edit"></i> Edit
+                            </button>
+                            <button
+                              className="btn btn-danger btn-sm"
+                              onClick={() => handleDelete(cycle.id)}
+                              disabled={showForm}
+                            >
+                              <i className="fas fa-trash"></i> Delete
+                            </button>
+                          </td>
+                        </tr>
+                      ))
+                    )}
+                  </tbody>
+                </table>
+              </div>
+            </div>
+          </div>
+
+          {showForm && (
+            <div className="mt-4">
+              <PerformanceCycleForm
+                item={editingItem}
+                onSubmit={handleFormSubmit}
+                onCancel={handleFormCancel}
+              />
+            </div>
+          )}
+        </div>
+      </section>
+    </AdminLayout>
+  );
+};
+
+export default PerformanceCyclesPage;

--- a/src/components/layout/Sidebar.tsx
+++ b/src/components/layout/Sidebar.tsx
@@ -91,27 +91,10 @@ const Sidebar: React.FC = () => {
 
             {/* Performance Cycles */}
             <li className="nav-item">
-              <a href="#" className="nav-link">
-                <i className="nav-icon fas fa-calendar-alt"></i>
-                <p>
-                  Performance Cycles
-                  <i className="fas fa-angle-left right"></i>
-                </p>
-              </a>
-              <ul className="nav nav-treeview">
-                <li className="nav-item">
-                  <Link href="/performance-cycles" className={`nav-link ${isActive('/performance-cycles')}`}>
-                    <i className="far fa-circle nav-icon"></i>
-                    <p>All Cycles</p>
-                  </Link>
-                </li>
-                <li className="nav-item">
-                  <Link href="/performance-cycles/add" className={`nav-link ${isActive('/performance-cycles/add')}`}>
-                    <i className="far fa-circle nav-icon"></i>
-                    <p>Add Cycle</p>
-                  </Link>
-                </li>
-              </ul>
+              <Link href="/performancecycles" className="nav-link">
+                <i className="nav-icon fas fa-sync-alt"></i>
+                <p>Performance Cycles</p>
+              </Link>
             </li>
 
             {/* Assessment Matrices */}

--- a/src/components/performancecycles/PerformanceCycleForm.tsx
+++ b/src/components/performancecycles/PerformanceCycleForm.tsx
@@ -1,0 +1,248 @@
+'use client';
+
+import React, { useEffect, useState } from 'react';
+import { useForm } from 'react-hook-form';
+import { PerformanceCycle, PerformanceCycleCreateDto } from '@/services/performanceCycleService';
+import { useTenant } from '@/contexts/TenantContext';
+
+interface PerformanceCycleFormProps {
+  item?: PerformanceCycle;
+  onSubmit: (data: PerformanceCycleCreateDto) => Promise<void>;
+  onCancel: () => void;
+}
+
+export const PerformanceCycleForm: React.FC<PerformanceCycleFormProps> = ({ item, onSubmit, onCancel }) => {
+  const { tenantId, companyId } = useTenant();
+  const [isSubmitting, setIsSubmitting] = useState(false);
+
+  const {
+    register,
+    handleSubmit,
+    formState: { errors },
+    reset,
+    watch,
+    setValue,
+    setError,
+    clearErrors
+  } = useForm<PerformanceCycleCreateDto>({
+    defaultValues: {
+      tenantId: tenantId || '',
+      companyId: companyId || '',
+      name: '',
+      description: '',
+      isActive: true,
+      isTimeSensitive: false,
+      startDate: '',
+      endDate: ''
+    }
+  });
+
+  const watchEndDate = watch('endDate');
+  const watchStartDate = watch('startDate');
+
+  useEffect(() => {
+    if (item) {
+      reset({
+        tenantId: item.tenantId,
+        companyId: item.companyId,
+        name: item.name,
+        description: item.description || '',
+        isActive: item.isActive,
+        isTimeSensitive: item.isTimeSensitive,
+        startDate: item.startDate ? new Date(item.startDate).toISOString().split('T')[0] : '',
+        endDate: item.endDate ? new Date(item.endDate).toISOString().split('T')[0] : ''
+      });
+    }
+  }, [item, reset]);
+
+  // Update isTimeSensitive based on endDate
+  useEffect(() => {
+    setValue('isTimeSensitive', !!watchEndDate);
+  }, [watchEndDate, setValue]);
+
+  // Validate date range
+  useEffect(() => {
+    if (watchStartDate && watchEndDate) {
+      const startDate = new Date(watchStartDate);
+      const endDate = new Date(watchEndDate);
+
+      if (startDate >= endDate) {
+        setError('endDate', {
+          type: 'manual',
+          message: 'End date must be after start date'
+        });
+      } else {
+        clearErrors('endDate');
+      }
+    }
+  }, [watchStartDate, watchEndDate, setError, clearErrors]);
+
+  const onFormSubmit = async (data: PerformanceCycleCreateDto) => {
+    // Validate dates before submission
+    if (data.startDate && data.endDate) {
+      const startDate = new Date(data.startDate);
+      const endDate = new Date(data.endDate);
+
+      if (startDate >= endDate) {
+        setError('endDate', {
+          type: 'manual',
+          message: 'End date must be after start date'
+        });
+        return; // Prevent form submission
+      }
+    }
+
+    setIsSubmitting(true);
+    try {
+      // Convert date strings to ISO format if they exist
+      const formattedData = {
+        ...data,
+        startDate: data.startDate ? new Date(data.startDate).toISOString() : undefined,
+        endDate: data.endDate ? new Date(data.endDate).toISOString() : undefined,
+        isTimeSensitive: !!data.endDate // Ensure isTimeSensitive matches business rule
+      };
+      await onSubmit(formattedData);
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  return (
+    <div className="card">
+      <div className="card-header">
+        <h3 className="card-title">
+          <i className="fas fa-sync-alt mr-2"></i>
+          {item ? 'Edit Performance Cycle' : 'New Performance Cycle'}
+        </h3>
+      </div>
+      <form onSubmit={handleSubmit(onFormSubmit)}>
+        <div className="card-body">
+          {/* Hidden fields for tenant context */}
+          <input type="hidden" {...register('tenantId')} />
+          <input type="hidden" {...register('companyId')} />
+
+          <div className="row">
+            <div className="col-md-6">
+              <div className="form-group">
+                <label htmlFor="name">
+                  Cycle Name <span className="text-danger">*</span>
+                </label>
+                <input
+                  type="text"
+                  className={`form-control ${errors.name ? 'is-invalid' : ''}`}
+                  id="name"
+                  placeholder="e.g., Q1 2024, Annual Review"
+                  {...register('name', { required: 'Cycle name is required' })}
+                />
+                {errors.name && (
+                  <div className="invalid-feedback">{errors.name.message}</div>
+                )}
+              </div>
+            </div>
+
+            <div className="col-md-6">
+              <div className="form-group">
+                <label htmlFor="isActive">Status</label>
+                <div className="custom-control custom-switch">
+                  <input
+                    type="checkbox"
+                    className="custom-control-input"
+                    id="isActive"
+                    {...register('isActive')}
+                  />
+                  <label className="custom-control-label" htmlFor="isActive">
+                    Active
+                  </label>
+                </div>
+                <small className="form-text text-muted">
+                  Active cycles can be used for assessments
+                </small>
+              </div>
+            </div>
+          </div>
+
+          <div className="form-group">
+            <label htmlFor="description">Description</label>
+            <textarea
+              className="form-control"
+              id="description"
+              rows={3}
+              placeholder="Enter cycle description (optional)"
+              {...register('description')}
+            />
+          </div>
+
+          <div className="row">
+            <div className="col-md-6">
+              <div className="form-group">
+                <label htmlFor="startDate">Start Date</label>
+                <input
+                  type="date"
+                  className="form-control"
+                  id="startDate"
+                  {...register('startDate')}
+                />
+                <small className="form-text text-muted">
+                  When this performance cycle begins
+                </small>
+              </div>
+            </div>
+
+            <div className="col-md-6">
+              <div className="form-group">
+                <label htmlFor="endDate">End Date</label>
+                <input
+                  type="date"
+                  className={`form-control ${errors.endDate ? 'is-invalid' : ''}`}
+                  id="endDate"
+                  {...register('endDate')}
+                />
+                {errors.endDate ? (
+                  <div className="invalid-feedback">{errors.endDate.message}</div>
+                ) : (
+                  <small className="form-text text-muted">
+                    Leave empty for ongoing cycles
+                  </small>
+                )}
+              </div>
+            </div>
+          </div>
+
+          {watchEndDate && (
+            <div className="alert alert-info">
+              <i className="fas fa-info-circle mr-2"></i>
+              This cycle is time-sensitive because an end date is specified.
+            </div>
+          )}
+        </div>
+
+        <div className="card-footer">
+          <div className="d-flex justify-content-end">
+            <button
+              type="button"
+              className="btn btn-secondary mr-2"
+              onClick={onCancel}
+              disabled={isSubmitting}
+            >
+              Cancel
+            </button>
+            <button
+              type="submit"
+              className="btn btn-primary"
+              disabled={isSubmitting || !!errors.endDate}
+            >
+              {isSubmitting ? (
+                <>
+                  <span className="spinner-border spinner-border-sm mr-2" role="status" aria-hidden="true"></span>
+                  {item ? 'Updating...' : 'Creating...'}
+                </>
+              ) : (
+                <>{item ? 'Update' : 'Create'} Cycle</>
+              )}
+            </button>
+          </div>
+        </div>
+      </form>
+    </div>
+  );
+};

--- a/src/services/performanceCycleService.ts
+++ b/src/services/performanceCycleService.ts
@@ -1,0 +1,41 @@
+import apiService from './apiService';
+import { CrudApi } from '../components/common/AbstractCRUD';
+
+export interface PerformanceCycle {
+  id: string;
+  tenantId: string;
+  companyId: string;
+  name: string;
+  description?: string;
+  isActive: boolean;
+  isTimeSensitive: boolean;
+  startDate?: string;
+  endDate?: string;
+  createdDate?: string;
+  lastUpdatedDate?: string;
+}
+
+export type PerformanceCycleCreateDto = Omit<PerformanceCycle, 'id' | 'createdDate' | 'lastUpdatedDate'>;
+export type PerformanceCycleUpdateDto = Partial<PerformanceCycleCreateDto>;
+
+export const performanceCycleService: CrudApi<PerformanceCycle> = {
+  getAll: async () => {
+    return await apiService.get<PerformanceCycle[]>('/performancecycles');
+  },
+
+  getById: async (id: string) => {
+    return await apiService.get<PerformanceCycle>(`/performancecycles/${id}`);
+  },
+
+  create: async (data: PerformanceCycleCreateDto) => {
+    return await apiService.post<PerformanceCycle>('/performancecycles', data);
+  },
+
+  update: async (id: string, data: PerformanceCycleUpdateDto) => {
+    return await apiService.put<PerformanceCycle>(`/performancecycles/${id}`, data);
+  },
+
+  delete: async (id: string) => {
+    await apiService.delete<void>(`/performancecycles/${id}`);
+  }
+};


### PR DESCRIPTION
## Summary
- Add complete Performance Cycle management UI following the existing patterns from Teams and Departments
- Implement full CRUD operations with search, filter, and sort capabilities
- Add date validation to ensure end date is after start date

## Changes
- Created  with TypeScript interfaces and CRUD API methods
- Added  component with:
  - Form validation using react-hook-form
  - Automatic isTimeSensitive setting based on end date
  - Hidden tenantId and companyId fields (populated from context)
  - Real-time date range validation
- Implemented  with:
  - Table view with sortable columns
  - Search functionality
  - Filter by active/inactive status
  - Visual indicators for cycle type and status
  - Inline edit and delete operations
- Updated sidebar navigation to include Performance Cycles link

## Test Plan
- [x] Create a new performance cycle without dates (ongoing cycle)
- [x] Create a new performance cycle with start and end dates
- [x] Verify that end date cannot be before or equal to start date
- [x] Edit an existing performance cycle
- [x] Delete a performance cycle
- [x] Test search functionality
- [x] Test filtering by active/inactive status
- [x] Test column sorting
- [x] Verify tenantId is automatically included in API calls